### PR TITLE
Add Go module and placeholder CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mcPort
 
-NCTの起動時に衝突していないポートを割り振るmcpサーバー
+MC-Port provides a lightweight daemon for dynamic port assignment and a
+simple CLI to interact with it.
 
-## ドキュメント
-詳細な設計情報は[docs/design.md](docs/design.md)を参照してください。
+The documentation for the planned API can be found in
+[docs/design.md](docs/design.md).

--- a/cmd/mcportctl/main.go
+++ b/cmd/mcportctl/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	serverAddr := flag.String("server", "http://127.0.0.1:8080", "mcportd address")
+	flag.Parse()
+
+	if len(os.Args) < 2 {
+		fmt.Println("usage: mcportctl <command> [options]")
+		fmt.Println("commands: allocate, register, release, list")
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	switch cmd {
+	case "allocate":
+		resp, err := http.Post(*serverAddr+"/allocate", "application/json", bytes.NewBuffer([]byte("{}")))
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		io.Copy(os.Stdout, resp.Body)
+	case "register":
+		// placeholder: send empty registration
+		resp, err := http.Post(*serverAddr+"/register", "application/json", bytes.NewBuffer([]byte("{}")))
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		io.Copy(os.Stdout, resp.Body)
+	case "release":
+		resp, err := http.Post(*serverAddr+"/release", "application/json", bytes.NewBuffer([]byte("{}")))
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		io.Copy(os.Stdout, resp.Body)
+	case "list":
+		resp, err := http.Get(*serverAddr + "/services")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var services interface{}
+		json.NewDecoder(resp.Body).Decode(&services)
+		b, _ := json.MarshalIndent(services, "", "  ")
+		fmt.Println(string(b))
+	default:
+		fmt.Println("unknown command:", cmd)
+		os.Exit(1)
+	}
+}

--- a/cmd/mcportd/main.go
+++ b/cmd/mcportd/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// Config represents a placeholder for server configuration.
+type Config struct {
+	PortRange struct {
+		Start int `json:"start"`
+		End   int `json:"end"`
+	} `json:"port_range"`
+	StorePath string `json:"store_path"`
+}
+
+func allocateHandler(w http.ResponseWriter, r *http.Request) {
+	resp := map[string]int{"port": 20010}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func registerHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func releaseHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func servicesHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode([]interface{}{})
+}
+
+func main() {
+	configPath := flag.String("config", "mcport.yaml", "path to config file")
+	addr := flag.String("addr", "127.0.0.1:8080", "listen address")
+	flag.Parse()
+
+	// TODO: load configuration from file
+	fmt.Printf("using config: %s\n", *configPath)
+
+	http.HandleFunc("/allocate", allocateHandler)
+	http.HandleFunc("/register", registerHandler)
+	http.HandleFunc("/release", releaseHandler)
+	http.HandleFunc("/services", servicesHandler)
+
+	log.Printf("mcportd listening on %s", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/mcport
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- initialize a Go module
- create `mcportd` and `mcportctl` command directories
- implement stub HTTP server matching the design API
- add a minimal README

## Testing
- `go build ./cmd/mcportd ./cmd/mcportctl`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860f5f6ec488326a17ba0b084ead4be