### PR TITLE
Add example configuration file

### DIFF
--- a/example/mcport.yaml
+++ b/example/mcport.yaml
@@ -1,0 +1,4 @@
+port_range:
+  start: 20000
+  end: 21000
+store_path: /var/lib/mcport/state.json


### PR DESCRIPTION
## Summary
- create `example/mcport.yaml` with sample settings
- ensure `docs/setup_guide.md` references `example/mcport.yaml`

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6860f5f53ca0832694175758a20590c0